### PR TITLE
feat: support Markdown and TXT file import and preview

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -42,7 +42,12 @@ function copyMigrationsPlugin() {
 
 export default defineConfig({
   main: {
-    plugins: [copyMigrationsPlugin()]
+    plugins: [copyMigrationsPlugin()],
+    build: {
+      rollupOptions: {
+        external: ['remark', 'remark-gfm', 'remark-parse', 'unified', 'unist-util-visit']
+      }
+    }
   },
   preload: {},
   renderer: {

--- a/src/main/services/KnowledgeService.ts
+++ b/src/main/services/KnowledgeService.ts
@@ -332,11 +332,18 @@ export class KnowledgeService {
       // 1. 创建文档记录（包含 localFilePath）
       onProgress?.('creating_document', 0)
 
+      // 根据 MIME 类型决定文档类型
+      // text/plain 和 text/markdown 可以直接预览
+      const docType =
+        parseResult.mimeType === 'text/plain' || parseResult.mimeType === 'text/markdown'
+          ? 'text'
+          : 'file'
+
       const newDoc: NewDocument = {
         id: documentId,
         notebookId,
         title: parseResult.title || basename(filePath) || 'Untitled',
-        type: 'file',
+        type: docType,
         sourceUri: filePath,
         localFilePath: localFilePath,
         content: parseResult.content,

--- a/src/main/services/loaders/MarkdownLoader.ts
+++ b/src/main/services/loaders/MarkdownLoader.ts
@@ -5,8 +5,7 @@
 
 import { readFile } from 'fs/promises'
 import { extname } from 'path'
-import { unified } from 'unified'
-import remarkParse from 'remark-parse'
+import { remark } from 'remark'
 import remarkGfm from 'remark-gfm'
 import { visit } from 'unist-util-visit'
 import type { Root, Heading, Content } from 'mdast'
@@ -40,7 +39,10 @@ export class MarkdownLoader implements IDocumentLoader {
 
     try {
       // 解析 Markdown AST
-      const processor = unified().use(remarkParse).use(remarkGfm)
+      // 处理 ESM/CommonJS 兼容性：在运行时获取正确的函数
+      const remarkFn = typeof remark === 'function' ? remark : (remark as any).remark
+      const remarkGfmPlugin = typeof remarkGfm === 'function' ? remarkGfm : (remarkGfm as any).default
+      const processor = remarkFn().use(remarkGfmPlugin)
       const ast = processor.parse(content) as Root
 
       // 提取标题


### PR DESCRIPTION
Fixes:
- Fix ESM/CommonJS compatibility issue in MarkdownLoader
- Use remark wrapper instead of unified + remark-parse
- Add runtime compatibility layer for module imports
- Configure electron-vite to externalize ESM dependencies

Improvements:
- Set document type intelligently based on MIME type
- Support direct preview for text/plain and text/markdown files
- View md/txt file content directly in knowledge base panel

Modified files:
- electron.vite.config.ts
- src/main/services/loaders/MarkdownLoader.ts
- src/main/services/KnowledgeService.ts