### PR TITLE
feat: add Ollama local LLM provider support

### DIFF
--- a/src/main/ipc/providerHandlers.ts
+++ b/src/main/ipc/providerHandlers.ts
@@ -91,6 +91,11 @@ export function registerProviderHandlers(providerManager: ProviderManager) {
           url = 'https://dashscope.aliyuncs.com/compatible-mode/v1/models'
         } else if (args.providerName === 'kimi') {
           url = 'https://api.moonshot.cn/v1/models'
+        } else if (args.providerName === 'ollama') {
+          // Ollama: 从配置获取 baseUrl，支持自定义服务器地址
+          const providerConfig = await providersManager.getProviderConfig(args.providerName)
+          const baseUrl = providerConfig?.config.baseUrl || 'http://localhost:11434/v1'
+          url = baseUrl.endsWith('/') ? `${baseUrl}models` : `${baseUrl}/models`
         } else {
           // 自定义供应商：从配置中获取 baseUrl
           const providerConfig = await providersManager.getProviderConfig(args.providerName)

--- a/src/main/providers/ProviderManager.ts
+++ b/src/main/providers/ProviderManager.ts
@@ -75,7 +75,8 @@ export class ProviderManager {
 
       // 如果用户设置了默认对话模型,解析并使用
       if (defaultChatModel && defaultChatModel.includes(':')) {
-        const [providerName, modelId] = defaultChatModel.split(':')
+        const [providerName, ...modelIdParts] = defaultChatModel.split(':')
+        const modelId = modelIdParts.join(':')
         const provider = await this.getConfiguredProvider(providerName)
 
         if (!provider) {
@@ -122,7 +123,8 @@ export class ProviderManager {
 
       // 如果用户设置了默认嵌入模型,解析并使用
       if (defaultEmbeddingModel && defaultEmbeddingModel.includes(':')) {
-        const [providerName, modelId] = defaultEmbeddingModel.split(':')
+        const [providerName, ...modelIdParts] = defaultEmbeddingModel.split(':')
+        const modelId = modelIdParts.join(':')
         const provider = await this.getConfiguredProvider(providerName)
 
         if (!provider) {

--- a/src/main/providers/registry/builtinProviders.ts
+++ b/src/main/providers/registry/builtinProviders.ts
@@ -80,6 +80,18 @@ export const BUILTIN_PROVIDERS: ProviderDescriptor[] = [
       embedding: true // SiliconFlow 作为模型聚合平台支持 embedding
     },
     createProvider: (descriptor) => new OpenAICompatibleProvider(descriptor)
+  },
+
+  {
+    name: 'ollama',
+    displayName: 'Ollama',
+    isBuiltin: true,
+    defaultBaseUrl: 'http://localhost:11434/v1',
+    capabilities: {
+      chat: true,
+      embedding: true
+    },
+    createProvider: (descriptor) => new OpenAICompatibleProvider(descriptor)
   }
 ]
 

--- a/src/renderer/src/components/settings/ProvidersSettings.tsx
+++ b/src/renderer/src/components/settings/ProvidersSettings.tsx
@@ -48,13 +48,14 @@ export default function ProvidersSettings({
     deepseek: 'https://api.deepseek.com',
     siliconflow: 'https://api.siliconflow.cn/v1',
     qwen: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
-    kimi: 'https://api.moonshot.cn/v1'
+    kimi: 'https://api.moonshot.cn/v1',
+    ollama: 'http://localhost:11434/v1'
   }
 
   // 加载已缓存的模型列表
   useEffect(() => {
     const loadCachedModels = async () => {
-      const providerList = ['deepseek', 'openai', 'siliconflow', 'qwen', 'kimi']
+      const providerList = ['deepseek', 'openai', 'siliconflow', 'qwen', 'kimi', 'ollama']
       const loadedModels: Record<string, Model[]> = {}
 
       for (const providerName of providerList) {
@@ -166,6 +167,7 @@ export default function ProvidersSettings({
   const siliconflowProvider = getProviderConfig('siliconflow')
   const qwenProvider = getProviderConfig('qwen')
   const kimiProvider = getProviderConfig('kimi')
+  const ollamaProvider = getProviderConfig('ollama')
 
   const providerList = [
     {
@@ -202,12 +204,19 @@ export default function ProvidersSettings({
       description: t('kimiDesc'),
       platformUrl: 'https://platform.moonshot.cn',
       enabled: kimiProvider.enabled
+    },
+    {
+      id: 'ollama',
+      name: 'Ollama',
+      description: 'Local LLM runner',
+      platformUrl: 'https://ollama.com',
+      enabled: ollamaProvider.enabled
     }
   ]
 
   // 获取自定义供应商列表
   const getCustomProviders = () => {
-    const builtInProviders = ['deepseek', 'openai', 'siliconflow', 'qwen', 'kimi']
+    const builtInProviders = ['deepseek', 'openai', 'siliconflow', 'qwen', 'kimi', 'ollama']
     return providers
       .filter((p) => !builtInProviders.includes(p.providerName))
       .map((p) => ({
@@ -474,8 +483,25 @@ export default function ProvidersSettings({
           />
         )}
 
+        {activeProvider === 'ollama' && (
+          <ProviderConfigPanel
+            displayName="Ollama"
+            description="Local LLM runner"
+            platformUrl="https://ollama.com"
+            provider={ollamaProvider}
+            models={models.ollama || []}
+            isFetching={fetchingModels.ollama || false}
+            onConfigChange={(config) => updateProviderConfig('ollama', { config })}
+            onEnabledChange={(enabled) => updateProviderConfig('ollama', { enabled })}
+            onFetchModels={() => fetchModels('ollama')}
+            defaultBaseUrl={defaultBaseUrls.ollama}
+          />
+        )}
+
         {/* 自定义供应商配置 */}
-        {!['deepseek', 'openai', 'siliconflow', 'qwen', 'kimi'].includes(activeProvider) &&
+        {!['deepseek', 'openai', 'siliconflow', 'qwen', 'kimi', 'ollama'].includes(
+          activeProvider
+        ) &&
           (() => {
             const customProvider = getProviderConfig(activeProvider)
             return customProvider && customProvider.providerName ? (


### PR DESCRIPTION
- Add Ollama to builtin providers with OpenAI-compatible API support
- Support both chat and embedding capabilities
- Default base URL: http://localhost:11434/v1
- Add Ollama model list endpoint handler with custom baseUrl support
- Fix model name truncation issue in ProviderManager
  - Preserve full model IDs including version numbers (e.g., qwen3:0.6b)
  - Affects both chat and embedding model parsing
- Add Ollama to frontend provider settings UI
  - Display in provider list with configuration panel
  - Support cached model loading and fetching